### PR TITLE
Add Previous and Next Page on Learn pages

### DIFF
--- a/learn/learn.js
+++ b/learn/learn.js
@@ -17,6 +17,19 @@ window.p5m = {
 p5m.ready = function () {
 	let pages = document.getElementsByClassName('page');
 	let pageNav = document.getElementById('pageNav');
+	let currentPage = 0;
+
+	let previousPage = document.createElement('a');
+	previousPage.innerText = 'Previous';
+	previousPage.onclick = function () {
+		if (currentPage - 1 > -1) {
+			let i = currentPage - 1;
+			let url = `?page=${i}`;
+			history.pushState({}, 'p5.play : Sprite : ' + i, url);
+			loadPage(i);
+		}
+	};
+	pageNav.appendChild(previousPage);
 
 	for (let i = 0; i < pages.length; i++) {
 		let a = document.createElement('a');
@@ -29,14 +42,26 @@ p5m.ready = function () {
 		pageNav.appendChild(a);
 	}
 
+	let nextPage = document.createElement('a');
+	nextPage.innerText = 'Next';
+	nextPage.onclick = function () {
+		if (currentPage + 1 < pages.length) {
+			let i = currentPage + 1;
+			let url = `?page=${i}`;
+			history.pushState({}, 'p5.play : Sprite : ' + i, url);
+			loadPage(i);
+		}
+	};
+	pageNav.appendChild(nextPage);
+
 	function loadPage(pageNum) {
 		pageNum = pageNum ?? args.page ?? 0;
 
 		for (let i = 0; i < pages.length; i++) {
 			if (i == pageNum) {
-				pageNav.children[i].className = 'active';
+				pageNav.children[i + 1].className = 'active';
 			} else {
-				pageNav.children[i].className = '';
+				pageNav.children[i + 1].className = '';
 			}
 		}
 		for (let mini of p5m.minis) {
@@ -50,6 +75,7 @@ p5m.ready = function () {
 		p5m.loadMinis(page);
 		document.body.scrollTop = 0; // for Safari
 		document.documentElement.scrollTop = 0; // Chrome, Firefox, and Opera
+		currentPage = parseInt(pageNum);
 	}
 
 	loadPage();


### PR DESCRIPTION
I didn't notice that the learn pages consisted of multiple subpages due to the pageNav didn't look like pageNav at all :yum:

![Capture](https://user-images.githubusercontent.com/1407800/194700090-9775f7bb-2ae4-4076-a4ee-16278395c2c3.PNG)

PS: That's very clever of you putting that pageNav on separate JavaScript file. I thought I have to modify all those learn pages to add previous and next link at first.