### PR TITLE
Update p5.play.js to redirect to p5play.js

### DIFF
--- a/v3/p5.play.js
+++ b/v3/p5.play.js
@@ -1,1 +1,4 @@
-throw `"p5.play" is now called "p5play"! This file, "https://p5play.org/v3/p5.play.js", is no longer available. Please use: "https://p5play.org/v3/p5play.js"`;
+var script = document.createElement("script");
+script.src = "https://p5play.org/v3/p5play.js";
+document.head.appendChild(script);
+console.warn("This script url, 'https://p5play.org/v3/p5.play.js' is no longer used. A redirect to the new url is provided for your convienence. Please switch to the new script url: 'https://p5play.org/v3/p5play.js'");


### PR DESCRIPTION
I've noticed that you've removed the p5.play.js file and moved the p5Play JS file to p5play.js. All that's there in p5.play.js is a throw telling the user that the developer needs to change files. Moving to a different file is fine, but the way that it's currently done breaks existing projects that use p5.play.js.

I know GitHub Pages doesn't support server-side redirects, so as an alternative, I've crafted an alternative p5.play.js file that warns in the console that the file has moved, and creates a new <script> tag that links to the new p5play.js file. It's really simple and keeps old projects working. I've tested this myself and confirmed that it works.

Please consider accepting this pull request for the sake of projects made before this change. Thank you.