### PR TITLE
Fix issue with getElementById() returning null

### DIFF
--- a/main/build.js
+++ b/main/build.js
@@ -63,8 +63,8 @@ async function translatePage(pageGroup, page) {
 
 		for (let tran of trans) {
 			let splitIdx = tran.indexOf('\n');
-			let id = tran.slice(0, splitIdx);
-			if (!isNaN(id[0])) id = 'md' + id;
+			let id = tran.slice(0, splitIdx - 1);
+			if (!isNaN(id)) id = 'md' + id;
 			let md = document.getElementById(id);
 			if (md) md.innerHTML = marked.parse(tran.slice(splitIdx + 1));
 		}

--- a/main/build.js
+++ b/main/build.js
@@ -64,7 +64,7 @@ async function translatePage(pageGroup, page) {
 		for (let tran of trans) {
 			let splitIdx = tran.indexOf('\n');
 			let id = tran.slice(0, splitIdx - 1);
-			if (!isNaN(id)) id = 'md' + id;
+			if (!isNaN(id[0])) id = 'md' + id;
 			let md = document.getElementById(id);
 			if (md) md.innerHTML = marked.parse(tran.slice(splitIdx + 1));
 		}


### PR DESCRIPTION
Issue:
All getElementById() calls were returning null.

Cause:
The string used to obtain the ID contained a newline character.

Resolution:
Modified the code to exclude newline characters when obtaining the ID string.