### PR TITLE
[fix] Fixed wrapping and overflow in Japanese, and adjusted font size at the smartphones.

### DIFF
--- a/index.css
+++ b/index.css
@@ -148,9 +148,6 @@ video {
 	overflow-x: visible;
 }
 
-html.ja #bigInfo h3 {
-	font-size: 2.4vw;
-}
 
 @keyframes scrollUp {
 

--- a/learn/style.css
+++ b/learn/style.css
@@ -252,6 +252,11 @@ a.navLink {
 	vertical-align: middle;
 }
 
+html.ja nav a,
+html.ja a.navLink {
+	flex: 1 0 auto;
+}
+
 a.navLink {
 	text-align: center;
 	line-height: 1.5;
@@ -586,7 +591,8 @@ footer p {
 		display: flex;
 		align-items: center;
 		width: 100%;
-		overflow: scroll;
+		overflow-x: scroll;
+		overflow-y: hidden;
 		gap: 10px;
 	}
 


### PR DESCRIPTION
- Fixed a style setting that is considered "layout breakdown" in Japan.
  - Fixed a problem where the content area extends vertically due to wrapping at a single character.
  - Specified scroll direction explicitly.
    - before:  
      ![もともとの折り返し](https://github.com/quinton-ashley/p5play-web/assets/11846146/d2364202-3fc1-4a5f-ab67-88def2bbc08a)
    - after:  
      ![折り返し](https://github.com/quinton-ashley/p5play-web/assets/11846146/54c82032-e8ea-49ac-a900-a31c43c8c641) ![折り返し２](https://github.com/quinton-ashley/p5play-web/assets/11846146/500e5b02-582f-4c32-b377-bf93a3d8d1f0)
- Corrected the style sheet so that the font size of Japanese characters on the top page is not reduced.
  - before:  
    ![もともとの大きさ](https://github.com/quinton-ashley/p5play-web/assets/11846146/823be3a2-eae4-4044-a78a-e97c6d5b45e2)
  - after:  
    ![惹句](https://github.com/quinton-ashley/p5play-web/assets/11846146/4d6c93ca-41b2-446d-b237-1a1348ad350d)