### PR TITLE
Fixed display corruption on smartphones and added a translator credit to myself in the footer section of each Japanese pages.

### DIFF
--- a/index.css
+++ b/index.css
@@ -554,6 +554,11 @@ body:not(.dark) #discord-brand img {
 	text-align: center;
 }
 
+html.ja #md14 {
+	word-break: keep-all;
+	overflow-wrap: anywhere;
+}
+
 #reviews {
 	display: flex;
 	justify-content: start;
@@ -588,6 +593,11 @@ body:not(.dark) #discord-brand img {
 
 footer {
 	margin-bottom: 300px;
+}
+
+html.ja footer {
+	word-break: keep-all;
+	overflow-wrap: anywhere;
 }
 
 #reel0 {
@@ -880,6 +890,10 @@ footer {
 		width: calc(100vw - 40px);
 	}
 
+	#md15 {
+		height: calc(100% - 40px);
+		overflow-y: auto;
+	}
 }
 
 @media screen and (max-width: 440px) {

--- a/lang/ja/index.html
+++ b/lang/ja/index.html
@@ -695,7 +695,8 @@ function dropSprite() {
 		<footer id="ft" class="text-small">
 			<p>p5play.org は<wbr> クイントン・アシュリー（@quinton-ashley）により<wbr>制作された<wbr>著作物です。<wbr> Copyright ©2022-2024. <a
 					href="mailto:info@p5play.org" target="_blank">info@p5play.org</a><wbr> p5play の<a
-					href="https://quinton-ashley.github.io/p5play-web-archive/v2" target="_blank">旧バージョンはこちら</a>。</p>
+					href="https://quinton-ashley.github.io/p5play-web-archive/v2" target="_blank">旧バージョンはこちら</a>。<br>翻訳:
+				<a href="https://github.com/ShiMeiWo" target="_blank">Shi MeiWo</a></p>
 		</footer>
 	</div>
 

--- a/lang/ja/index.html
+++ b/lang/ja/index.html
@@ -516,9 +516,9 @@ function dropSprite() {
 
 				<div class="full">
 					<md id="md14">
-						<h2 id="40000-人のアクティブユーザーに参加しましょう！">+40,000 人のアクティブユーザーに参加しましょう！</h2>
-						<h3 id="まずは、インタラクティブな「学ぶ」ページから始めましょう。">まずは、インタラクティブな<a href="learn/sprite.html"
-								target="_blank">「学ぶ」</a>ページから始めましょう。</h3>
+						<h2 id="40000-人のアクティブユーザーに参加しましょう！">+40,000 人の<wbr>アクティブユーザーに<wbr>参加しましょう！</h2>
+						<h3 id="まずは、インタラクティブな「学ぶ」ページから始めましょう。">まずは、<wbr>インタラクティブな<wbr><a href="learn/sprite.html"
+								target="_blank">「学ぶ」</a>ページ<wbr>から<wbr>始めましょう。</h3>
 					</md>
 				</div>
 
@@ -532,7 +532,7 @@ function dropSprite() {
 			<div class="page">
 				<div class="spacer"></div>
 				<md id="md15">
-					<h2 id="quinton-ashley-によって作成されました">Quinton Ashley によって作成されました</h2>
+					<h2 id="quinton-ashley-により作成">Quinton Ashley により作成</h2>
 					<p>私、 Quinton Ashley （クイントン・アシュリー）は、ゲームデザインに情熱を燃やすコンピュータ・サイエンスの教育者で、 7 年の指導経験があります！</p>
 				</md>
 			</div>
@@ -693,8 +693,8 @@ function dropSprite() {
 		</div>
 
 		<footer id="ft" class="text-small">
-			<p>p5play.org は クイントン・アシュリー（@quinton-ashley）により制作された著作物です。 Copyright ©2022-2024。<a
-					href="mailto:info@p5play.org" target="_blank">info@p5play.org</a>. p5play の<a
+			<p>p5play.org は<wbr> クイントン・アシュリー（@quinton-ashley）により<wbr>制作された<wbr>著作物です。<wbr> Copyright ©2022-2024. <a
+					href="mailto:info@p5play.org" target="_blank">info@p5play.org</a><wbr> p5play の<a
 					href="https://quinton-ashley.github.io/p5play-web-archive/v2" target="_blank">旧バージョンはこちら</a>。</p>
 		</footer>
 	</div>

--- a/lang/ja/index.md
+++ b/lang/ja/index.md
@@ -114,13 +114,13 @@ p5play に関するあなたのレビューを[info@p5play.org](mailto:info@p5pl
 
 # 14
 
-## +40,000 人のアクティブユーザーに参加しましょう！
+## +40,000 人の<wbr />アクティブユーザーに<wbr />参加しましょう！
 
-### まずは、インタラクティブな[「学ぶ」](learn/sprite.html)ページから始めましょう。
+### まずは、<wbr />インタラクティブな<wbr />[「学ぶ」](learn/sprite.html)ページ<wbr />から<wbr />始めましょう。
 
 # 15
 
-## Quinton Ashley によって作成されました
+## Quinton Ashley により作成
 
 私、 Quinton Ashley （クイントン・アシュリー）は、ゲームデザインに情熱を燃やすコンピュータ・サイエンスの教育者で、 7 年の指導経験があります！
 
@@ -272,4 +272,4 @@ p5play の裏で使用されている Box2D の JavaScript 移植版 planck.js �
 
 # ft
 
-p5play.org は クイントン・アシュリー（@quinton-ashley）により制作された著作物です。 Copyright ©2022-2024。[info@p5play.org](mailto:info@p5play.org). p5play の[旧バージョンはこちら](https://quinton-ashley.github.io/p5play-web-archive/v2)。
+p5play.org は<wbr /> クイントン・アシュリー（@quinton-ashley）により<wbr />制作された<wbr />著作物です。<wbr /> Copyright ©2022-2024. [info@p5play.org](mailto:info@p5play.org)<wbr /> p5play の[旧バージョンはこちら](https://quinton-ashley.github.io/p5play-web-archive/v2)。

--- a/lang/ja/index.md
+++ b/lang/ja/index.md
@@ -272,4 +272,4 @@ p5play の裏で使用されている Box2D の JavaScript 移植版 planck.js �
 
 # ft
 
-p5play.org は<wbr /> クイントン・アシュリー（@quinton-ashley）により<wbr />制作された<wbr />著作物です。<wbr /> Copyright ©2022-2024. [info@p5play.org](mailto:info@p5play.org)<wbr /> p5play の[旧バージョンはこちら](https://quinton-ashley.github.io/p5play-web-archive/v2)。
+p5play.org は<wbr /> クイントン・アシュリー（@quinton-ashley）により<wbr />制作された<wbr />著作物です。<wbr /> Copyright ©2022-2024. [info@p5play.org](mailto:info@p5play.org)<wbr /> p5play の[旧バージョンはこちら](https://quinton-ashley.github.io/p5play-web-archive/v2)。<br />翻訳: [Shi MeiWo](https://github.com/ShiMeiWo)

--- a/lang/ja/ja.json
+++ b/lang/ja/ja.json
@@ -26,7 +26,7 @@
 		"DOM": {
 			"prevPage": "前へ",
 			"nextPage": "次へ",
-			"credits": "制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024",
+			"credits": "<p>制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</p><p>翻訳: <a href=\"https://github.com/ShiMeiWo\" target=\"_blank\">Shi MeiWo</a></p>",
 			"getStarted": "始める！"
 		},
 		"camera": ["カメラの移動", "カメラのズーム", "カメラのオン・オフ", "カメラにおけるマウスイベント"],

--- a/lang/ja/learn/animation.html
+++ b/lang/ja/learn/animation.html
@@ -434,7 +434,10 @@ if (hero.ani.name != 'jump' && hero.ani.name != 'roll') {
 			<a id="nextPage" class="navLink">次へ</a>
 		</div>
 		<div class="break"></div>
-		<footer id="credits" class="text-small">制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</footer>
+		<footer id="credits" class="text-small">
+			<p>制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</p>
+			<p>翻訳: <a href="https://github.com/ShiMeiWo" target="_blank">Shi MeiWo</a></p>
+		</footer>
 	</article>
 
 	<script src="/v3/q5.min.js"></script>

--- a/lang/ja/learn/camera.html
+++ b/lang/ja/learn/camera.html
@@ -193,7 +193,10 @@ function draw() {
 			<a id="nextPage" class="navLink">次へ</a>
 		</div>
 		<div class="break"></div>
-		<footer id="credits" class="text-small">制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</footer>
+		<footer id="credits" class="text-small">
+			<p>制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</p>
+			<p>翻訳: <a href="https://github.com/ShiMeiWo" target="_blank">Shi MeiWo</a></p>
+		</footer>
 	</article>
 
 	<script src="/v3/q5.min.js"></script>

--- a/lang/ja/learn/canvas.html
+++ b/lang/ja/learn/canvas.html
@@ -112,7 +112,10 @@ function draw() {
 			<a id="nextPage" class="navLink">次へ</a>
 		</div>
 		<div class="break"></div>
-		<footer id="credits" class="text-small">制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</footer>
+		<footer id="credits" class="text-small">
+			<p>制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</p>
+			<p>翻訳: <a href="https://github.com/ShiMeiWo" target="_blank">Shi MeiWo</a></p>
+		</footer>
 	</article>
 
 	<script src="/v3/q5.min.js"></script>

--- a/lang/ja/learn/group.html
+++ b/lang/ja/learn/group.html
@@ -398,7 +398,10 @@ function draw() {
 			<a id="nextPage" class="navLink">次へ</a>
 		</div>
 		<div class="break"></div>
-		<footer id="credits" class="text-small">制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</footer>
+		<footer id="credits" class="text-small">
+			<p>制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</p>
+			<p>翻訳: <a href="https://github.com/ShiMeiWo" target="_blank">Shi MeiWo</a></p>
+		</footer>
 	</article>
 
 	<!-- <script src="https://cdn.jsdelivr.net/npm/p5@1/lib/p5.js"></script> -->

--- a/lang/ja/learn/index.html
+++ b/lang/ja/learn/index.html
@@ -141,7 +141,10 @@
 		</div>
 
 		<div class="break"></div>
-		<footer id="credits" class="text-small">制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</footer>
+		<footer id="credits" class="text-small">
+			<p>制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</p>
+			<p>翻訳: <a href="https://github.com/ShiMeiWo" target="_blank">Shi MeiWo</a></p>
+		</footer>
 	</article>
 
 	<script src="/learn/main.js"></script>

--- a/lang/ja/learn/input.html
+++ b/lang/ja/learn/input.html
@@ -328,7 +328,10 @@ function draw() {
 			<a id="nextPage" class="navLink">次へ</a>
 		</div>
 		<div class="break"></div>
-		<footer id="credits" class="text-small">制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</footer>
+		<footer id="credits" class="text-small">
+			<p>制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</p>
+			<p>翻訳: <a href="https://github.com/ShiMeiWo" target="_blank">Shi MeiWo</a></p>
+		</footer>
 	</article>
 
 	<script src="/v3/q5.min.js"></script>

--- a/lang/ja/learn/joints.html
+++ b/lang/ja/learn/joints.html
@@ -264,7 +264,10 @@ function draw() {
 			<a id="nextPage" class="navLink">次へ</a>
 		</div>
 		<div class="break"></div>
-		<footer id="credits" class="text-small">制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</footer>
+		<footer id="credits" class="text-small">
+			<p>制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</p>
+			<p>翻訳: <a href="https://github.com/ShiMeiWo" target="_blank">Shi MeiWo</a></p>
+		</footer>
 	</article>
 
 	<script src="/v3/q5.min.js"></script>

--- a/lang/ja/learn/sound.html
+++ b/lang/ja/learn/sound.html
@@ -64,7 +64,10 @@ function draw() {
 			<a id="nextPage" class="navLink">次へ</a>
 		</div>
 		<div class="break"></div>
-		<footer id="credits" class="text-small">制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</footer>
+		<footer id="credits" class="text-small">
+			<p>制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</p>
+			<p>翻訳: <a href="https://github.com/ShiMeiWo" target="_blank">Shi MeiWo</a></p>
+		</footer>
 	</article>
 
 	<script src="/v3/q5.min.js"></script>

--- a/lang/ja/learn/sprite.html
+++ b/lang/ja/learn/sprite.html
@@ -1624,7 +1624,10 @@ if (distance > 40) {
 			<a id="nextPage" class="navLink">次へ</a>
 		</div>
 		<div class="break"></div>
-		<footer id="credits" class="text-small">制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</footer>
+		<footer id="credits" class="text-small">
+			<p>制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</p>
+			<p>翻訳: <a href="https://github.com/ShiMeiWo" target="_blank">Shi MeiWo</a></p>
+		</footer>
 	</article>
 
 	<!-- <script src="https://cdn.jsdelivr.net/npm/p5@1/lib/p5.min.js"></script> -->

--- a/lang/ja/learn/tiles.html
+++ b/lang/ja/learn/tiles.html
@@ -154,7 +154,10 @@ function draw() {
 			<a id="nextPage" class="navLink">次へ</a>
 		</div>
 		<div class="break"></div>
-		<footer id="credits" class="text-small">制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</footer>
+		<footer id="credits" class="text-small">
+			<p>制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</p>
+			<p>翻訳: <a href="https://github.com/ShiMeiWo" target="_blank">Shi MeiWo</a></p>
+		</footer>
 	</article>
 
 	<script src="/v3/q5.min.js"></script>

--- a/lang/ja/learn/world.html
+++ b/lang/ja/learn/world.html
@@ -183,7 +183,10 @@ function draw() {
 			<a id="nextPage" class="navLink">次へ</a>
 		</div>
 		<div class="break"></div>
-		<footer id="credits" class="text-small">制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</footer>
+		<footer id="credits" class="text-small">
+			<p>制作・著作: クイントン・アシュリー（@quinton-ashley） ©2022-2024</p>
+			<p>翻訳: <a href="https://github.com/ShiMeiWo" target="_blank">Shi MeiWo</a></p>
+		</footer>
 	</article>
 
 	<script src="/v3/q5.min.js"></script>


### PR DESCRIPTION
Revision to https://github.com/quinton-ashley/p5play-web/issues/36

- ref: https://github.com/quinton-ashley/p5play-web/pull/34#issuecomment-2063086625 
  - ```css
    #md15 {
        height: calc(100% - 40px);
        overflow-y: auto;
    }
    ```
- Shortened translation of index text "Quinton Ashley によって作成されました" into "Quinton Ashley により作成".
- Suppressed unnatural line breaks in Japanese within `{text-align: center}` blocks.
  - Added `<wbr />` tags between each "Bunsetsu" (文節, lit. "Clauses in a sentence". It means phrases or chunks in the Japanese sentence) to text in the blocks in `ja/index.md`.
  - Added style `{word-break: keep-all;overflow-wrap: anywhere;}` to the blocks.

Knowledges:

- About styling:
  - https://developer.mozilla.org/docs/Web/CSS/word-break
  - https://developer.mozilla.org/docs/Web/CSS/overflow-wrap
- About Bunsetsu:
  - (Japanese page) https://ja.wikipedia.org/w/index.php?curid=310020
    - Translated by ChatGPT:  
      > A "bunsetsu" is the smallest unit in Japanese grammar (both classical and modern Japanese grammar) that can be divided without creating unnatural breaks when words are segmented. It is also a unit pronounced without pausing in spoken language. Although there is some discrepancy between linguistic and terminological usage, it is similar to what linguists refer to as a "word."